### PR TITLE
refactor: add timestamp utility and user orders query parameter

### DIFF
--- a/src/lib/services/order/index.ts
+++ b/src/lib/services/order/index.ts
@@ -4,6 +4,7 @@ import type {
   TOrder,
   TOrderStatus
 } from '$lib/types/order';
+import { getCurrentISOTimestamp } from '$lib/utils';
 
 export const createOrder = async (
   data: TCreateOrderRequest
@@ -38,6 +39,9 @@ export const getOrdersByShopId = async (
 };
 
 export const getUserOrders = async (userId: string): Promise<TOrder[]> => {
-  const response = await api.get(`/orders/user/${userId}`);
+  const createdAt = getCurrentISOTimestamp();
+  const response = await api.get(
+    `/orders/user/${userId}?createdAt=${createdAt}`
+  );
   return response.data;
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -50,6 +50,10 @@ export function getInitials(
   return email ? email[0].toUpperCase() : 'U';
 }
 
+export function getCurrentISOTimestamp(): string {
+  return new Date().toISOString();
+}
+
 export function objectToFormData(obj: Record<string, unknown>): FormData {
   const formData = new FormData();
 


### PR DESCRIPTION
## Description
This PR introduces a reusable timestamp utility function and enhances the user orders API call with a `createdAt` query parameter for better filtering and consistency.

## Summary of Changes
- Added `getCurrentISOTimestamp()` utility function to `src/lib/utils.ts` for generating ISO timestamp strings
- Updated `getUserOrders()` in `src/lib/services/order/index.ts` to include a `createdAt` query parameter in the API request
- Imported and utilized the new timestamp utility in the order service

## How to Test
1. Verify that the `getCurrentISOTimestamp()` function returns a valid ISO 8601 timestamp string
2. Test the `getUserOrders()` function to ensure it correctly appends the `createdAt` parameter to the API request
3. Check that the API endpoint `/orders/user/:userId` properly receives and handles the `createdAt` query parameter
4. Run existing e2e tests to ensure no regressions

## Additional Notes
This refactoring improves code reusability and prepares the codebase for better temporal filtering of user orders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a reusable ISO timestamp utility and updates `getUserOrders` to include a `createdAt` query parameter.
> 
> - **Services**:
>   - Update `src/lib/services/order/index.ts`:
>     - `getUserOrders(userId)` now appends `createdAt` (from current ISO timestamp) to the request URL.
>     - Imports `getCurrentISOTimestamp` from `src/lib/utils.ts`.
> - **Utils**:
>   - Add `getCurrentISOTimestamp()` in `src/lib/utils.ts` to return `new Date().toISOString()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2c0aeb54a797081a84fbe70c265f56e5991e986. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->